### PR TITLE
More adaptive virtualenv check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VENV_NAME=venv
+VENV_NAME=$(shell if test "$$VIRTUAL_ENV" != "";then echo "$$VIRTUAL_ENV";else echo "venv";fi)
 PIP=$(VENV_NAME)/bin/pip
 TOX=`which tox`
 GARDEN=$(VENV_NAME)/bin/garden
@@ -42,8 +42,8 @@ endif
 all: system_dependencies virtualenv opencv
 
 venv:
-	test -d venv || virtualenv -p python$(PYTHON_MAJOR_VERSION) venv
-	. venv/bin/activate
+	test "$$VIRTUAL_ENV" != "" || virtualenv -p python$(PYTHON_MAJOR_VERSION) venv
+	. $(VENV_NAME)/bin/activate
 	$(PIP) install Cython==0.28.6
 	$(PIP) install -r requirements/requirements.txt
 	$(GARDEN) install xcamera


### PR DESCRIPTION
Check if the `VIRTUAL_ENV` variable is set instead of checking if the `venv` directory exists, so that if we `make` while already being in a venv (for example if zbarcam is a dependency), we don't create another one.