### PR TITLE
Fix decode error from possible image mode mismatch

### DIFF
--- a/tests/test_zbarcam.py
+++ b/tests/test_zbarcam.py
@@ -49,8 +49,12 @@ class TestZBarCam(unittest.TestCase):
         texture = Image(fixture_path).texture
         code_types = self.zbarcam.code_types
         symbols = self.zbarcam._detect_qrcode_frame(texture, code_types)
-        # currently detects no codes, but that's a bug
-        self.assertEqual(symbols, [])
+        self.assertEqual(
+            symbols, [
+                ZBarCam.Symbol(type='QRCODE', data=b'zbarlight test qr code'),
+                ZBarCam.Symbol(type='UPCA', data=b'012345678905')
+            ]
+        )
 
     def test_detect_qrcode_frame_two_qrcodes(self):
         """

--- a/zbarcam/zbarcam.py
+++ b/zbarcam/zbarcam.py
@@ -91,13 +91,7 @@ class ZBarCam(AnchorLayout):
     def _detect_qrcode_frame(cls, texture, code_types):
         image_data = texture.pixels
         size = texture.size
-        fmt = texture.colorfmt.upper()
-        # PIL doesn't support BGRA but IOS uses BGRA for the camera
-        # if BGRA is detected it will switch to RGBA, color will be off
-        # but we don't care as it's just looking for barcodes
-        if cls.is_ios() and fmt == 'BGRA':
-            fmt = 'RGBA'
-        pil_image = PIL.Image.frombytes(mode=fmt, size=size, data=image_data)
+        pil_image = PIL.Image.frombytes(mode='RGBA', size=size, data=image_data)
         pil_image = cls._fix_android_image(pil_image)
         symbols = []
         codes = pyzbar.decode(pil_image, symbols=code_types)

--- a/zbarcam/zbarcam.py
+++ b/zbarcam/zbarcam.py
@@ -91,7 +91,12 @@ class ZBarCam(AnchorLayout):
     def _detect_qrcode_frame(cls, texture, code_types):
         image_data = texture.pixels
         size = texture.size
-        pil_image = PIL.Image.frombytes(mode='RGBA', size=size, data=image_data)
+        # Fix for mode mismatch between texture.colorfmt and data returned by
+        # texture.pixels. texture.pixels always returns RGBA, so that should
+        # be passed to PIL no matter what texture.colorfmt returns. refs:
+        # https://github.com/AndreMiras/garden.zbarcam/issues/41
+        pil_image = PIL.Image.frombytes(mode='RGBA', size=size,
+                                        data=image_data)
         pil_image = cls._fix_android_image(pil_image)
         symbols = []
         codes = pyzbar.decode(pil_image, symbols=code_types)


### PR DESCRIPTION
Changed call to PIL.Image.frombytes to always use mode='RGBA' rather
than determining mode from texture.colorfmt.  texture.pixels always
returns data as RGBA, so no other mode is ever appropriate to use.

Associated issue #41